### PR TITLE
H2のバージョンを2.2.220に更新しました

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
     <dependency>
       <groupId>com.h2database</groupId>
       <artifactId>h2</artifactId>
-      <version>2.1.214</version>
+      <version>2.2.220</version>
     </dependency>
 
     <dependency>
@@ -192,7 +192,7 @@
           <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
-            <version>2.1.214</version>
+            <version>2.2.220</version>
           </dependency>
         </dependencies>
         <executions>


### PR DESCRIPTION
https://github.com/nablarch/nablarch-example-db-queue/pull/32
の対応